### PR TITLE
feat(Viewer): add lifecycle events for #saveXML

### DIFF
--- a/lib/Viewer.js
+++ b/lib/Viewer.js
@@ -190,6 +190,16 @@ Viewer.prototype.importXML = function(xml, done) {
  * Export the currently displayed CMMN 1.1 diagram as
  * a CMMN 1.1 XML document.
  *
+ * ## Life-Cycle Events
+ *
+ * During XML saving the viewer will fire life-cycle events:
+ *
+ *   * saveXML.start (before serialization)
+ *   * saveXML.serialized (after xml generation)
+ *   * saveXML.done (everything done)
+ *
+ * You can use these events to hook into the life-cycle.
+ *
  * @param {Object} [options] export options
  * @param {Boolean} [options.format=false] output formated XML
  * @param {Boolean} [options.preamble=true] output preamble
@@ -203,13 +213,37 @@ Viewer.prototype.saveXML = function(options, done) {
     options = {};
   }
 
+  var self = this;
+
   var definitions = this._definitions;
 
   if (!definitions) {
     return done(new Error('no definitions loaded'));
   }
 
-  this._moddle.toXML(definitions, options, done);
+  // allow to fiddle around with definitions
+  definitions = this._emit('saveXML.start', {
+    definitions: definitions
+  }) || definitions;
+
+  this._moddle.toXML(definitions, options, function(err, xml) {
+
+    try {
+      xml = self._emit('saveXML.serialized', {
+        error: err,
+        xml: xml
+      }) || xml;
+
+      self._emit('saveXML.done', {
+        error: err,
+        xml: xml
+      });
+    } catch (e) {
+      console.error('error in saveXML life-cycle listener', e);
+    }
+
+    done(err, xml);
+  });
 };
 
 Viewer.prototype.saveSVG = function(options, done) {

--- a/test/spec/ViewerSpec.js
+++ b/test/spec/ViewerSpec.js
@@ -242,7 +242,74 @@ describe('Viewer', function() {
   });
 
 
-  describe('export', function() {
+  describe('#saveXML', function() {
+
+    it('should export XML', function(done) {
+
+      // given
+      var xml = require('../fixtures/cmmn/simple.cmmn');
+
+      createViewer(xml, function(err, warnings, viewer) {
+
+        // when
+        viewer.saveXML({ format: true }, function(err, xml) {
+
+          // then
+          expect(xml).to.contain('<?xml version="1.0" encoding="UTF-8"?>');
+          expect(xml).to.contain('<cmmn:definitions');
+          expect(xml).to.contain('  ');
+
+          done();
+        });
+      });
+
+    });
+
+
+    it('should emit <saveXML.*> events', function(done) {
+
+      var xml = require('../fixtures/cmmn/simple.cmmn');
+
+      createViewer(xml, function(err, warnings, viewer) {
+
+        var events = [];
+
+        viewer.on([
+          'saveXML.start',
+          'saveXML.serialized',
+          'saveXML.done'
+        ], function(e) {
+          // log event type + event arguments
+          events.push([
+            e.type,
+            Object.keys(e).filter(function(key) {
+              return key !== 'type';
+            })
+          ]);
+        });
+
+        viewer.importXML(xml, function(err) {
+
+          // when
+          viewer.saveXML(function(err) {
+            // then
+            console.log('events', events);
+            expect(events).to.eql([
+              [ 'saveXML.start', [ 'definitions' ] ],
+              [ 'saveXML.serialized', ['error', 'xml' ] ],
+              [ 'saveXML.done', ['error', 'xml' ] ]
+            ]);
+
+            done(err);
+          });
+        });
+      });
+    });
+
+  });
+
+
+  describe('#saveSVG', function() {
 
     function currentTime() {
       return new Date().getTime();


### PR DESCRIPTION
The Viewer will now emit following events on saveXML:
* `saveXML.start`
* `saveXML.serialized`
* `saveXML.done`
