### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ ___Note:__ Yet to be released changes appear here._
 ## 0.16.0
 
 * `FEAT`: add ability to move selection with keyboard arrows
-* `FEAT`: support `SHIFT` modifier to move elements / canvas with keyboard arrows at accelerated speed
+* `FEAT`: support `SHIFT` modifier to move elements/canvas with keyboard arrows at an accelerated speed
 * `FEAT`: require `Ctrl/Cmd` to be pressed as a modifier key to move the canvas via keyboard errors
 * `FEAT`: auto-expand elements when children resize
 * `CHORE`: bind editor actions and keyboard shortcuts for explicitly added features only
@@ -52,7 +52,7 @@ ___Note:__ Yet to be released changes appear here._
 ### Breaking Changes
 
 * `CmmnGlobalConnect` provider got removed. Use `connection.start` rule to decide whether an element can start a connection.
-* `EditorActions` / `Keyboard` do not pull in features implicitly anymore. If you roll your own editor, include features you would like to ship with manually to provide the respective actions / keyboard bindings.
+* `EditorActions` / `Keyboard` do not pull in features implicitly anymore. If you roll your own editor, include features you would like to ship with manually to provide the respective actions/keyboard bindings.
 * Moving the canvas with keyboard arrows now requires the `Ctrl/Cmd` modifiers to be pressed.
 
 ## 0.15.2


### PR DESCRIPTION
In line 54, 'an' is added before accelerated.
In line 46, extra spacing between elements and canvas removed.
In line 55, extra spacing between actions and keyboard is removed.

<!--

Thanks for creating this pull request!

Please make sure you provide the relevant context.

-->

__Which issue does this PR address?_

Closes #